### PR TITLE
bug: request-routes missing s

### DIFF
--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -2,7 +2,7 @@ const router = require("express").Router();
 
 const session_routes = require("./session-routes");
 const skill_routes = require("./skill-routes");
-const request_routes = require("./request-route");
+const request_routes = require("./request-routes");
 
 router.use("/sessions", session_routes);
 router.use("/skill", skill_routes);


### PR DESCRIPTION
Added s that was missing on the end of the ./request-routes in api index.js.